### PR TITLE
upgrade jquery and grunt to more recent versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "csv": "^0.4.1",
     "dateformat": "^2.0.0",
     "express": "^4.13.1",
-    "jquery": "^2.1.3",
+    "jquery": ">=3.5.0",
     "request": "^2.59.0",
     "twitter": "^1.2.5",
     "underscore": "^1.8.3"
@@ -20,7 +20,7 @@
     "browserify": "^9.0.7",
     "coffee-script": "^1.9.1",
     "coffeeify": "^1.0.0",
-    "grunt": "^0.4.5",
+    "grunt": ">=1.3.0",
     "grunt-browserify": "^3.6.0",
     "jade": "^1.9.2",
     "jasmine": "^2.2.1",


### PR DESCRIPTION
Fix Dependabot issues with JQuery and Grunt -- none of the mentioned specific problems are relevant for this specific code, but the versions used in the repo are generally very-very old, and should be updated if possible:

JQuery:

> Passing HTML from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code.

Grunt:

> The package grunt before 1.3.0 are vulnerable to Arbitrary Code Execution due to the default usage of the function load() instead of its secure replacement safeLoad() of the package js-yaml inside grunt.file.readYAML.

I've done some minimal testing and can confirm that it builds and the basic pages load without problems (looking at the [JQuery major changelog for 3.0](https://jquery.com/upgrade-guide/3.0/) I dont think there are any breaking changes, but  my assumptions are not good replacements for real-world tests.